### PR TITLE
Convert relative image URLs to absolute URLs

### DIFF
--- a/lib/jekyll-image-cache.rb
+++ b/lib/jekyll-image-cache.rb
@@ -5,7 +5,10 @@ require "nokogiri"
 
 module Jekyll
   class ImageCache
+    extend Jekyll::Filters::URLFilters
+
     def self.process(content)
+      @context ||= Context.new(content.site)
       html = content.output
       content.output = process_tags(html) if process_tags?(html)
     end
@@ -25,7 +28,7 @@ module Jekyll
       tags = content.css("img[src].u-photo")
       # TODO: Make the cache service and size configurable
       tags.each do |tag|
-        orig_url = tag["src"].sub(%r!https?://!, "")
+        orig_url = absolute_url(tag["src"]).sub(%r!https?://!, "")
         unless orig_url.include? "images.weserv.nl"
           tag["src"] = "//images.weserv.nl/?url=#{orig_url}&w=640"
         end
@@ -35,6 +38,18 @@ module Jekyll
 
     private_class_method :process_tags
     private_class_method :process_tags?
+  end
+
+  class Context
+    attr_reader :site
+
+    def initialize(site)
+      @site = site
+    end
+
+    def registers
+      { :site => site }
+    end
   end
 end
 

--- a/spec/fixtures/unit/_posts/2021-03-17-post-with-relative-img.md
+++ b/spec/fixtures/unit/_posts/2021-03-17-post-with-relative-img.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Post with relative img url
+---
+
+![alt](/imgs/example.png){:class="u-photo"}

--- a/spec/jekyll-image-cache_spec.rb
+++ b/spec/jekyll-image-cache_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe(Jekyll::ImageCache) do
     find_by_title(posts, "Post with cached html <img> tag")
   end
 
+  let(:post_with_relative_img) do
+    find_by_title(posts, "Post with relative img url")
+  end
+
   let(:document_with_liquid_tag) do
     find_by_title(site.collections["docs"].docs, "Document with liquid tag")
   end
@@ -74,6 +78,12 @@ RSpec.describe(Jekyll::ImageCache) do
       it "changes src to cached url" do
         expect(document_with_liquid_tag.output).to include(<<~HTML)
           <p>This <img src="/docs/document-with-liquid-tag.html"> is an image with a liquid tag.</p>
+        HTML
+      end
+
+      it "changes relative src to cached url" do
+        expect(post_with_relative_img.output).to include(<<~HTML)
+        <p><img src="//images.weserv.nl/?url=example.com/imgs/example.png&amp;w=640" alt="alt" class="u-photo"></p>
         HTML
       end
     end

--- a/spec/jekyll-image-cache_spec.rb
+++ b/spec/jekyll-image-cache_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe(Jekyll::ImageCache) do
 
       it "changes relative src to cached url" do
         expect(post_with_relative_img.output).to include(<<~HTML)
-        <p><img src="//images.weserv.nl/?url=example.com/imgs/example.png&amp;w=640" alt="alt" class="u-photo"></p>
+          <p><img src="//images.weserv.nl/?url=example.com/imgs/example.png&amp;w=640" alt="alt" class="u-photo"></p>
         HTML
       end
     end


### PR DESCRIPTION
If you use relative URLs for your images, eg `![alt](/imgs/example.png)`, the plugin was creating cache URLs using this, eg `src="//images.weserv.nl/?url=/imgs/example.png&amp;w=640"` which won't work as images.weserv.nl needs an absolute URL.

This PR ensures the URL is always an absolute URL.